### PR TITLE
Create different macroses for vector init

### DIFF
--- a/p/riscv_test.h
+++ b/p/riscv_test.h
@@ -25,7 +25,17 @@
 
 #define RVTEST_RV64MV                                                   \
   .macro init;                                                          \
-  RVTEST_MVECTOR_ENABLE;                                                 \
+  RVTEST_MVECTOR_ENABLE;                                                \
+  .endm
+
+#define RVTEST_RV64UFV                                                  \
+  .macro init;                                                          \
+  RVTEST_FP_VECTOR_ENABLE;                                              \
+  .endm
+
+#define RVTEST_RV64MFV                                                  \
+  .macro init;                                                          \
+  RVTEST_FP_MVECTOR_ENABLE;                                             \
   .endm
 
 #define RVTEST_RV32U                                                    \
@@ -44,7 +54,17 @@
 
 #define RVTEST_RV32MV                                                   \
   .macro init;                                                          \
-  RVTEST_MVECTOR_ENABLE;                                                 \
+  RVTEST_MVECTOR_ENABLE;                                                \
+  .endm
+
+#define RVTEST_RV32UFV                                                  \
+  .macro init;                                                          \
+  RVTEST_FP_VECTOR_ENABLE;                                              \
+  .endm
+
+#define RVTEST_RV32MFV                                                  \
+  .macro init;                                                          \
+  RVTEST_FP_MVECTOR_ENABLE;                                             \
   .endm
 
 #define RVTEST_RV64M                                                    \
@@ -149,13 +169,24 @@
   csrwi fcsr, 0
 
 #define RVTEST_VECTOR_ENABLE                                            \
+  li a0, (MSTATUS_VS & (MSTATUS_VS >> 1));                              \
+  csrs mstatus, a0;                                                     \
+  csrwi vcsr, 0;
+
+#define RVTEST_MVECTOR_ENABLE                                           \
+  li a0, (MSTATUS_VS & (MSTATUS_VS >> 1)) |                             \
+         (MSTATUS_MPP);                                                 \
+  csrs mstatus, a0;                                                     \
+  csrwi vcsr, 0;
+
+#define RVTEST_FP_VECTOR_ENABLE                                         \
   li a0, (MSTATUS_VS & (MSTATUS_VS >> 1)) |                             \
          (MSTATUS_FS & (MSTATUS_FS >> 1));                              \
   csrs mstatus, a0;                                                     \
   csrwi fcsr, 0;                                                        \
   csrwi vcsr, 0;
 
-#define RVTEST_MVECTOR_ENABLE                                           \
+#define RVTEST_FP_MVECTOR_ENABLE                                        \
   li a0, (MSTATUS_VS & (MSTATUS_VS >> 1)) |                             \
          (MSTATUS_FS & (MSTATUS_FS >> 1)) |                             \
          (MSTATUS_MPP);                                                 \


### PR DESCRIPTION
This patch adds vector initial macros without floating point.